### PR TITLE
newlib nano ported as draft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,14 @@
 # C Compiler preprocessor option
 include COMMON.mk
 
-include $(PORT_SRC_DIR)/port.mk
-include $(HAL_SRC_DIR)/hal.mk
-include $(KERNEL_SRC_DIR)/sys.mk
-include $(USR_SRC_DIR)/usr.mk
 
 TARGET=$(GEN_DIR)/tachyos.elf
 
 
-LIBS=-L'C:\Program Files\GNU Tools ARM Embedded\4.8 2014q2\arm-none-eabi\lib\armv7-m\'
-LIB_DIR=-lc_s\
-        -lg_s
+LIBS=-lnosys\
+     -lg_s\
+        
+LIB_DIR=-L'C:\Program Files\GNU Tools ARM Embedded\4.8 2014q2\arm-none-eabi\lib\armv7-m\'
 
 CFLAG+=\
        -D$(HW_PLF)\
@@ -35,13 +32,25 @@ ifneq ($(LIBS),)
 	CFLAG+=--specs=nano.specs
 endif
 
+DBG_FLAG=-D__USE_MALLOC
+CPFLAG+=$(DBG_FLAG)
+CFLAG+=$(DBG_FLAG)
+
+
+include $(PORT_SRC_DIR)/port.mk
+include $(HAL_SRC_DIR)/hal.mk
+include $(KERNEL_SRC_DIR)/sys.mk
+include $(USR_SRC_DIR)/usr.mk
+
+
+
 MMAP_FLAG = -Wl,-Map,$(TARGET:%.elf=%.map)
 
 TARGET_SIZE = $(TARGET:%.elf=%.siz)
 TARGET_FLASH = $(TARGET:%.elf=%.hex) 
 TARGET_BINARY = $(TARGET:%.elf=%.bin)
 
-all : $(TARGET) $(TARGET_FLASH) $(TARGET_SIZE) $(TARGET_BINARY)
+all : $(TARGET) $(TARGET_FLASH) $(TARGET_BINARY) $(TARGET_SIZE)
 
 $(TARGET): $(OBJS)
 	@echo "Generating ELF"

--- a/include/hal/STM32F40_41xxx/ld/flash.ld
+++ b/include/hal/STM32F40_41xxx/ld/flash.ld
@@ -140,6 +140,7 @@ SECTIONS
         _sbss = .;
         
         *(.bss)
+        *(.bss.*)
         *(COMMON)
         
 	    . = ALIGN(4);
@@ -155,10 +156,10 @@ SECTIONS
     */
     .heap :
     {
-    	. = ALIGN(4);
+    	. = ALIGN(8);
     	_sheap = .;
     	*(.heap)
-    	. = ALIGN(4);
+    	. = ALIGN(8);
     	_eheap = .;
     } >RAM
     

--- a/source/sys/tch_crtb.cpp
+++ b/source/sys/tch_crtb.cpp
@@ -18,12 +18,18 @@
 #include "tch_kernel.h"
 
 void* operator new(size_t size) throw() {
-	//return malloc(size);
+#ifdef __USE_MALLOC
+	return malloc(size);
+#else
 	return ((tch*)Sys)->Mem->alloc(size);
+#endif
 }
 void operator delete(void* p){
-	//free(p);
+#ifdef __USE_MALLOC
+	free(p);
+#else
 	((tch*)Sys)->Mem->free(p);
+#endif
 }
 
 extern "C" int __aeabi_atexit(void *object,void (*)(void*),void *dso_handle){

--- a/source/sys/tch_sys.c
+++ b/source/sys/tch_sys.c
@@ -55,8 +55,9 @@ void tch_kernelInit(void* arg){
 
 
 	tch_port_kernel_lock();
+#ifndef __USE_MALLOC
 	tch_sys_instance.tch_heap_handle = tch_memInit((uint8_t*)&Heap_Base,(uint32_t)&Heap_Limit - (uint32_t)&Heap_Base);
-
+#endif
 	tch* api = (tch*) &tch_sys_instance;
 	api->Thread = Thread;
 	api->Mtx = Mtx;
@@ -91,7 +92,7 @@ void tch_kernelSvCall(uint32_t sv_id,uint32_t arg1, uint32_t arg2){
 		tch_schedSleep(arg1,SLEEP);    ///< put current thread in the pend queue and update timeout value in the thread header
 		return;
 	case SV_THREAD_JOIN:
-		tch_schedSuspend(&((tch_thread_header*)arg1)->t_joinQ,arg2);
+		tch_schedSuspend((tch_thread_queue*)&((tch_thread_header*)arg1)->t_joinQ,arg2);
 		return;
 	case SV_THREAD_RESUME:
 		nth = tch_schedResume((tch_thread_queue*)arg1);

--- a/source/usr/main.cpp
+++ b/source/usr/main.cpp
@@ -37,9 +37,12 @@ tch_gpio_handle* led  = NULL;
 tch_gpio_handle* btn  = NULL;
 
 int main(void* arg) {
-	tch* api = (tch*) arg;
+
+
 	person* p = new person();
 	delete p;
+	tch* api = (tch*) arg;
+
 	tch_gpio_cfg iocfg;
 	tch_gpio_evCfg evcfg;
 	evcfg.EvType = api->Device->gpio->EvType.Interrupt;
@@ -56,6 +59,7 @@ int main(void* arg) {
 	iocfg.PuPd = api->Device->gpio->PuPd.PullUp;
 	btn = api->Device->gpio->allocIo(gpIo_5,10,&iocfg,osWaitForever,NoActOnSleep);
 
+
 	btn->registerIoEvent(btn,&evcfg,onBtnPressed);
 
 	tch_thread_cfg thcfg;
@@ -67,8 +71,7 @@ int main(void* arg) {
 	childThread = api->Thread->create(&thcfg,arg);
 	api->Thread->start(childThread);
 
-
-	float fVal = 0.1f;
+	float fVal = 0.f;
 	while(1){
 		fVal += 0.02f;
 		led->out(led,bSet);
@@ -76,10 +79,11 @@ int main(void* arg) {
 		led->out(led,bClear);
 		api->Thread->sleep(100);
 		btn->listen(btn,osWaitForever);
-	//	classroom* clp = new classroom();
-	//	classroom* acls = (classroom*)malloc(sizeof(classroom));
-	//	delete clp;
-	//	free(acls);
+		classroom* clp = new classroom();
+
+		classroom* acls = (classroom*)malloc(sizeof(classroom));
+		delete clp;
+		free(acls);
 	}
 	return 0;
 }
@@ -98,6 +102,7 @@ DECLARE_THREADROUTINE(childthread_routine){
 	iocfg.Otype = api->Device->gpio->Otype.PushPull;
 	iocfg.Speed = api->Device->gpio->Speed.Low;
 	tch_gpio_handle* bled = api->Device->gpio->allocIo(gpIo_5,7,&iocfg,osWaitForever,ActOnSleep);
+
 	while(1){
 		bled->out(bled,bSet);
 		api->Thread->sleep(20);


### PR DESCRIPTION
- malloc,free have shown unexpected operation. its cause is figured out
  as below
  1. my own implemented heap manager was corrupting heap memory region which is also used by newlib stub function (like _sbrk_r)
  2. heap was not aligned by 8 bytes

after fix then, malloc and free don’t show any problem
