### PR TITLE
1. Fix Thread Stack initialization

### DIFF
--- a/include/port/ARM/cortex-m0+/tch_port.h
+++ b/include/port/ARM/cortex-m0+/tch_port.h
@@ -124,7 +124,6 @@ struct _tch_thread_context {
 	uint32_t S30;
 	uint32_t S31;
 #endif
-	uint32_t kRetv;
 }__attribute__((aligned(8)));
 
 

--- a/include/port/ARM/cortex-m0/tch_port.h
+++ b/include/port/ARM/cortex-m0/tch_port.h
@@ -124,7 +124,6 @@ struct _tch_thread_context {
 	uint32_t S30;
 	uint32_t S31;
 #endif
-	uint32_t kRetv;
 }__attribute__((aligned(8)));
 
 

--- a/include/port/ARM/cortex-m3/tch_port.h
+++ b/include/port/ARM/cortex-m3/tch_port.h
@@ -47,7 +47,15 @@ extern void tch_port_jmpToKernelModeThread(void* routine,uint32_t arg1,uint32_t 
 extern int tch_port_enterSvFromUsr(int sv_id,uint32_t arg1,uint32_t arg2);
 extern int tch_port_enterSvFromIsr(int sv_id,uint32_t arg1,uint32_t arg2);
 extern void* tch_port_makeInitialContext(void* sp,void* initfn);
-
+/*!
+ * \brief arch. specific exclusive compare
+ * \param[out] dest the target memory compared
+ * \param[in] comp the compare value
+ * \param[in] the value updated to dest, if two comparees are different from
+ * \return if equal return 0, greater than comp return 1, otherwise -1
+ */
+extern int tch_port_exclusiveCompare(int* dest,int comp,int update);
+extern int tch_port_atomicCompareModify(int* dval,int* tval);
 
 typedef struct _tch_exc_stack tch_exc_stack;
 typedef struct _tch_thread_context tch_thread_context;
@@ -124,7 +132,6 @@ struct _tch_thread_context {
 	uint32_t S30;
 	uint32_t S31;
 #endif
-	uint32_t kRetv;
 }__attribute__((aligned(8)));
 
 

--- a/include/port/ARM/cortex-m4/tch_port.h
+++ b/include/port/ARM/cortex-m4/tch_port.h
@@ -16,6 +16,7 @@
 #define TCHtch_port_H_
 
 #include "tch.h"
+#include "tch_ktypes.h"
 
 #define GROUP_PRIOR_Pos                (uint8_t) (7)
 #define SUB_PRIOR_Pos                  (uint8_t) (4)
@@ -88,22 +89,22 @@ struct _tch_exc_stack {
 	uint32_t Return;
 	uint32_t xPSR;
 #if MFEATURE_HFLOAT
-	uint32_t S0;
-	uint32_t S1;
-	uint32_t S2;
-	uint32_t S3;
-	uint32_t S4;
-	uint32_t S5;
-	uint32_t S6;
-	uint32_t S7;
-	uint32_t S8;
-	uint32_t S9;
-	uint32_t S10;
-	uint32_t S11;
-	uint32_t S12;
-	uint32_t S13;
-	uint32_t S14;
-	uint32_t S15;
+	float S0;
+	float S1;
+	float S2;
+	float S3;
+	float S4;
+	float S5;
+	float S6;
+	float S7;
+	float S8;
+	float S9;
+	float S10;
+	float S11;
+	float S12;
+	float S13;
+	float S14;
+	float S15;
 	uint32_t FPSCR;
 	uint32_t RESV;
 #endif
@@ -120,24 +121,23 @@ struct _tch_thread_context {
 	uint32_t R11;
 	uint32_t LR;
 #if MFEATURE_HFLOAT
-	uint32_t S16;
-	uint32_t S17;
-	uint32_t S18;
-	uint32_t S19;
-	uint32_t S20;
-	uint32_t S21;
-	uint32_t S22;
-	uint32_t S23;
-	uint32_t S24;
-	uint32_t S25;
-	uint32_t S26;
-	uint32_t S27;
-	uint32_t S28;
-	uint32_t S29;
-	uint32_t S30;
-	uint32_t S31;
+	float S16;
+	float S17;
+	float S18;
+	float S19;
+	float S20;
+	float S21;
+	float S22;
+	float S23;
+	float S24;
+	float S25;
+	float S26;
+	float S27;
+	float S28;
+	float S29;
+	float S30;
+	float S31;
 #endif
-	uint32_t kRetv;
 }__attribute__((aligned(8)));
 
 

--- a/include/sys/tch_kernel.h
+++ b/include/sys/tch_kernel.h
@@ -21,109 +21,14 @@
  *   - Initialize kernel enviroment (init kernel internal objects,
  */
 #include "tch.h"
+#include "tch_ktypes.h"
 #include "tch_port.h"
 #include "hal/tch_hal.h"
 #include "tch_halcfg.h"
 #include "tch_mem.h"
 #include "tch_list.h"
 
-
-#define MTX(Sys)          ((tch*)Sys)->Mtx
-
-
-/***
- *  Supervisor call table
- */
-typedef struct tch_kernel_instance{
-	tch                     tch_api;
-	tch_mem_handle*         tch_heap_handle;
-} tch_kernel_instance;
-
-
-typedef enum tch_thread_state_t {
-	PENDED = 1,                              // state in which thread is created but not started yet (waiting in ready queue)
-	RUNNING = 2,                             // state in which thread occupies cpu
-	READY = 3,
-	WAIT = 4,                                // state in which thread wait for event (wake)
-	SLEEP = 5,                               // state in which thread is yield cpu for given amount of time
-	TERMINATED = -1                          // state in which thread has finished its task
-} tch_thread_state;
-
-
-typedef struct tch_signal_t {
-	int32_t                 match_target;
-	int32_t                 signal;
-	tch_lnode_t             sig_wq;
-}tch_signal;
-
-
-typedef struct tch_thread_header {
-	tch_lnode_t                 t_schedNode;   ///<extends genericlist node class
-	tch_lnode_t                 t_waitNode;
-	tch_lnode_t                 t_joinQ;      ///<thread queue to wait for this thread's termination
-	tch_lnode_t*                t_waitQ;      ///<reference to wait queue in which this thread is waiting
-	tch_thread_routine          t_fn;         ///<thread function pointer
-	const char*                 t_name;       ///<thread name /* currently not implemented */
-	void*                       t_arg;        ///<thread arg field
-	uint32_t                    t_lckCnt;
-	uint32_t                    t_tslot;
-	tch_thread_state            t_state;
-	uint32_t                    t_prior;
-	uint32_t                    t_svd_prior;
-	uint64_t                    t_to;
-	tch_thread_context*         t_ctx;
-	tch_signal                  t_sig;
-	void*                       t_reent;       ///< binary tree entry node for data owned soley by thread (means reentrant data)
-	uint32_t                    t_chks;
-} tch_thread_header   __attribute__((aligned(8)));
-
-typedef struct tch_thread_queue{
-	tch_lnode_t             thque;
-} tch_thread_queue;
-
-
-
-
-typedef struct tch_async_cb_t {
-	tch_lnode_t                     ln;
-	int (*fn)(uint32_t,void*);
-	void*                           arg;
-	volatile uint8_t                status;
-	uint8_t                         prior;
-	tch_thread_queue                wq;
-}tch_async_cb;
-
-
-#define SV_RETURN_TO_KTHREAD             ((uint32_t) 0x01)              /**
-                                                                      *  Return to temporal thread mode in kernel mode
-                                                                      *   - Simplify Thread Context Switching OP.
-                                                                      *
-                                                                      */
-#define SV_EXIT_FROM_SV                  ((uint32_t) 0x02)
-
-#define SV_MTX_LOCK                      ((uint32_t) 0x10)
-#define SV_MTX_UNLOCK                    ((uint32_t) 0x11)
-#define SV_MTX_DESTROY                   ((uint32_t) 0x12)
-
-#define SV_SIG_MATCH                     ((uint32_t) 0x14)
-#define SV_SIG_WAIT                      ((uint32_t) 0x15)
-
-
-#define SV_THREAD_START                  ((uint32_t) 0x20)              ///< Supervisor call id for starting thread
-#define SV_THREAD_TERMINATE              ((uint32_t) 0x21)              ///< Supervisor call id for terminate thread      /* Not Implemented here */
-#define SV_THREAD_SLEEP                  ((uint32_t) 0x22)              ///< Supervisor call id for yeild cpu for specific  amount of time
-#define SV_THREAD_JOIN                   ((uint32_t) 0x23)              ///< Supervisor call id for wait another thread is terminated
-#define SV_THREAD_SUSPEND                ((uint32_t) 0x24)
-#define SV_THREAD_RESUME                 ((uint32_t) 0x25)
-#define SV_THREAD_RESUMEALL              ((uint32_t) 0x26)
-
-#define SV_MEM_MALLOC                    ((uint32_t) 0x27)
-#define SV_MEM_FREE                      ((uint32_t) 0x28)
-
-#define SV_ASYNC_START                   ((uint32_t) 0x2A)               ///< Supervisor call id to start async task
-#define SV_ASYNC_BLSTART                 ((uint32_t) 0x2B)               ///< Supervisor call id to start async task with blocking current execution
-#define SV_ASYNC_NOTIFY                  ((uint32_t) 0x2C)               ///< Supervisor call id to notify async task result
-
+#define tch_kernelSetResult(th,result) ((tch_thread_header*) th)->t_kRet = result
 
 
 extern void tch_kernelInit(void* arg);
@@ -144,6 +49,7 @@ extern int Main_Stack_Limit asm("main_stack_limit");
 
 extern int Idle_Stack_Top asm("idle_stack_top");
 extern int Idle_Stack_Limit asm("idle_stack_limit");
+extern tch_thread_id tch_currentThread;
 
 
 
@@ -165,5 +71,7 @@ extern const tch_mem_ix* Mem;
 extern const tch_hal* Hal;
 
 extern const tch_kernel_instance* Sys;
+
+
 
 #endif /* TCH_KERNEL_H_ */

--- a/include/sys/tch_ktypes.h
+++ b/include/sys/tch_ktypes.h
@@ -9,5 +9,105 @@
 #define TCH_KTYPES_H_
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+/***
+ *  Supervisor call table
+ */
+typedef struct tch_kernel_instance{
+	tch                     tch_api;
+	tch_mem_handle*         tch_heap_handle;
+} tch_kernel_instance;
+
+
+typedef enum tch_thread_state_t {
+	PENDED = 1,                              // state in which thread is created but not started yet (waiting in ready queue)
+	RUNNING = 2,                             // state in which thread occupies cpu
+	READY = 3,
+	WAIT = 4,                                // state in which thread wait for event (wake)
+	SLEEP = 5,                               // state in which thread is yield cpu for given amount of time
+	TERMINATED = -1                          // state in which thread has finished its task
+} tch_thread_state;
+
+
+typedef struct tch_signal_t {
+	int32_t                 match_target;
+	int32_t                 signal;
+	tch_lnode_t             sig_wq;
+}tch_signal;
+
+
+typedef struct tch_thread_header {
+	tch_lnode_t                 t_schedNode;   ///<extends genericlist node class
+	tch_lnode_t                 t_waitNode;
+	tch_lnode_t                 t_joinQ;      ///<thread queue to wait for this thread's termination
+	tch_lnode_t*                t_waitQ;      ///<reference to wait queue in which this thread is waiting
+	tch_thread_routine          t_fn;         ///<thread function pointer
+	const char*                 t_name;       ///<thread name /* currently not implemented */
+	void*                       t_arg;        ///<thread arg field
+	uint32_t                    t_lckCnt;
+	uint32_t                    t_tslot;
+	tch_thread_state            t_state;
+	uint32_t                    t_prior;
+	uint32_t                    t_svd_prior;
+	uint64_t                    t_to;
+	void*                       t_ctx;
+	tch_signal                  t_sig;
+	tchStatus                   t_kRet;
+	uint32_t                    t_chks;
+} tch_thread_header   __attribute__((aligned(8)));
+
+typedef struct tch_thread_queue{
+	tch_lnode_t             thque;
+} tch_thread_queue;
+
+
+
+
+typedef struct tch_async_cb_t {
+	tch_lnode_t                     ln;
+	int (*fn)(uint32_t,void*);
+	void*                           arg;
+	volatile uint8_t                status;
+	uint8_t                         prior;
+	tch_thread_queue                wq;
+}tch_async_cb;
+
+
+#define SV_EXIT_FROM_SV                  ((uint32_t) 0x02)
+
+#define SV_MTX_LOCK                      ((uint32_t) 0x10)
+#define SV_MTX_UNLOCK                    ((uint32_t) 0x11)
+#define SV_MTX_DESTROY                   ((uint32_t) 0x12)
+
+#define SV_SIG_MATCH                     ((uint32_t) 0x14)
+#define SV_SIG_WAIT                      ((uint32_t) 0x15)
+
+
+#define SV_THREAD_START                  ((uint32_t) 0x20)              ///< Supervisor call id for starting thread
+#define SV_THREAD_TERMINATE              ((uint32_t) 0x21)              ///< Supervisor call id for terminate thread      /* Not Implemented here */
+#define SV_THREAD_SLEEP                  ((uint32_t) 0x22)              ///< Supervisor call id for yeild cpu for specific  amount of time
+#define SV_THREAD_JOIN                   ((uint32_t) 0x23)              ///< Supervisor call id for wait another thread is terminated
+#define SV_THREAD_SUSPEND                ((uint32_t) 0x24)
+#define SV_THREAD_RESUME                 ((uint32_t) 0x25)
+#define SV_THREAD_RESUMEALL              ((uint32_t) 0x26)
+
+#define SV_MEM_MALLOC                    ((uint32_t) 0x27)
+#define SV_MEM_FREE                      ((uint32_t) 0x28)
+
+#define SV_ASYNC_START                   ((uint32_t) 0x2A)               ///< Supervisor call id to start async task
+#define SV_ASYNC_BLSTART                 ((uint32_t) 0x2B)               ///< Supervisor call id to start async task with blocking current execution
+#define SV_ASYNC_NOTIFY                  ((uint32_t) 0x2C)               ///< Supervisor call id to notify async task result
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TCH_KTYPES_H_ */

--- a/include/tch.h
+++ b/include/tch.h
@@ -16,7 +16,9 @@
 
 #ifndef TCH_H_
 #define TCH_H_
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "tch_TypeDef.h"
 
 
@@ -104,5 +106,7 @@ typedef struct _tch_t {
  * tachyos generic data interface
  */
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* TCH_H_ */

--- a/include/usr/main.h
+++ b/include/usr/main.h
@@ -15,6 +15,14 @@
 #ifndef MAIN_H_
 #define MAIN_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int main(void*);
 
+
+#ifdef __cplusplus
+}
+#endif
 #endif /* MAIN_H_ */

--- a/source/hal/STM32F40_41xxx/tch_dma.c
+++ b/source/hal/STM32F40_41xxx/tch_dma.c
@@ -161,6 +161,7 @@ typedef struct tch_dma_handle_prototype_t{
 	tch_lnode_t                 wq;
 	tch_dma_eventListener       listener;
 	uint32_t                    status;
+	tch_async_id                dma_async;
 }tch_dma_handle_prototype;
 
 static void tch_dma_initCfg(tch_dma_cfg* cfg);
@@ -258,6 +259,7 @@ static tch_dma_handle* tch_dma_initHandle(dma_t dma,uint8_t ch){
 	dma_handle->status = 0;
 	Mtx->create(&dma_handle->mtx);
 	tch_listInit(&dma_handle->wq);
+	dma_handle->dma_async = Async->create(tch_dma_trigger,dma_handle,Async->Prior.Normal);
 
 	return (tch_dma_handle*)dma_handle;
 }
@@ -273,8 +275,9 @@ static BOOL tch_dma_beginXfer(tch_dma_handle* self,uint32_t size,uint32_t timeou
 	DMA_Stream_TypeDef* dmaHw = (DMA_Stream_TypeDef*)dma_desc->_hw;
 	dmaHw->NDTR = size;
 	ins->status |= DMA_FLAG_BUSY;
-	dmaHw->CR |= DMA_SxCR_EN;
-	tch_port_enterSvFromUsr(SV_THREAD_SUSPEND,(uint32_t)&ins->wq,rtime);
+	Async->blockedstart(ins->dma_async,timeout);
+	//dmaHw->CR |= DMA_SxCR_EN;
+	//tch_port_enterSvFromUsr(SV_THREAD_SUSPEND,(uint32_t)&ins->wq,rtime);
 	Mtx->unlock(&ins->mtx);
 	return TRUE;
 }
@@ -379,7 +382,21 @@ static void tch_dma_close(tch_dma_handle* self){
 static BOOL tch_dma_handleIrq(tch_dma_handle_prototype* handle,tch_dma_descriptor* dma_desc){
 	uint32_t isr = *dma_desc->_isr >> dma_desc->ipos;
 	if(handle){
+		if(isr & DMA_FLAG_EvFE){
 
+		}
+		if(isr & DMA_FLAG_EvHT){
+
+		}
+		if(isr & DMA_FLAG_EvDME){
+
+		}
+		if(isr & DMA_FLAG_EvTC){
+
+		}
+		if(isr & DMA_FLAG_EvTE){
+
+		}
 	}else{
 		if(isr & DMA_FLAG_EvFE){
 

--- a/source/hal/STM32F40_41xxx/tch_gpio.c
+++ b/source/hal/STM32F40_41xxx/tch_gpio.c
@@ -244,7 +244,7 @@ uint32_t tch_gpio_getPinAvailable(const gpIo_x port){
 
 void tch_gpio_freeIo(tch_gpio_handle* IoHandle){
 	tch_gpio_handle_prototype* _handle = (tch_gpio_handle_prototype*) IoHandle;
-	MTX(Sys)->destroy(&_handle->mtx);
+	Mtx->destroy(&_handle->mtx);
 }
 
 
@@ -273,11 +273,11 @@ tchStatus tch_gpio_handle_registerIoEvent(tch_gpio_handle_prototype* _handle,con
 	if(ioIrqOjb->io_occp)
 		return osErrorResource;
 	tch_listInit(&ioIrqOjb->wq);
-	result = MTX(Sys)->lock(&_handle->mtx,osWaitForever);
+	result = Mtx->lock(&_handle->mtx,osWaitForever);
 	_handle->cb = callback;
 	ioIrqOjb->io_occp = _handle;
 	tch_gpio_setIrq(_handle,cfg);
-	result = MTX(Sys)->unlock(&_handle->mtx);
+	result = Mtx->unlock(&_handle->mtx);
 
 	return result;
 }
@@ -360,7 +360,6 @@ void tch_gpio_initGpioHandle(tch_gpio_handle_prototype* handle){
 	handle->_pix.configure = tch_gpio_handle_configure;
 	handle->pMsk = 0;
 
-	tch_mtx_ix* Mtx = (tch_mtx_ix*)(((tch*) Sys)->Mtx);
 	Mtx->create(&handle->mtx);
 	handle->cb = NULL;
 	tch_listInit(&handle->wq);

--- a/source/sys/tch_crtb.cpp
+++ b/source/sys/tch_crtb.cpp
@@ -21,14 +21,14 @@ void* operator new(size_t size) throw() {
 #ifdef __USE_MALLOC
 	return malloc(size);
 #else
-	return ((tch*)Sys)->Mem->alloc(size);
+	return Mem->alloc(size);
 #endif
 }
 void operator delete(void* p){
 #ifdef __USE_MALLOC
 	free(p);
 #else
-	((tch*)Sys)->Mem->free(p);
+	Mem->free(p);
 #endif
 }
 

--- a/source/sys/tch_mtx.c
+++ b/source/sys/tch_mtx.c
@@ -71,6 +71,45 @@ tchStatus tch_mtx_lock(tch_mtx* mtx,uint32_t timeout){
 	}
 }
 
+/*
+tchStatus tch_mtx_lock(tch_mtx* mtx,uint32_t timeout){
+	if(tch_port_isISR()){
+		tch_kernel_errorHandler(FALSE,osErrorISR);
+		return osErrorISR;
+	}else{
+		if(mtx->key < MTX_INIT_MARK)
+			return osErrorParameter;
+		while(TRUE){
+			int tid = (int)Thread->self();
+			if(!tch_port_exclusiveCompare(&mtx->key,tid,tid)){
+				return osOK;
+			}
+
+			if(tch_port_enterSvFromUsr(SV_THREAD_SUSPEND,&mtx->que,timeout) != osOK){
+				return osErrorTimeoutResource;
+			}
+		}
+		return osErrorResource;
+	}
+}*/
+
+/*
+tchStatus tch_mtx_unlock(tch_mtx* mtx){
+	if(tch_port_isISR()){
+		return osErrorISR;
+	}else{
+		if(mtx->key != Thread->self())
+			return osErrorParameter;
+		if(mtx->key == MTX_INIT_MARK)
+			return osErrorResource;
+		if(tch_port_exclusiveCompare(&mtx->key,MTX_INIT_MARK,MTX_INIT_MARK)){
+			tch_port_enterSvFromUsr(SV_THREAD_RESUME,&mtx->que,0);
+		}
+	}
+}
+*/
+
+
 tchStatus tch_mtx_unlock(tch_mtx* mtx){
 	if(tch_port_isISR()){                               ///< check if in isr mode, then return osErrorISR
 		tch_kernel_errorHandler(FALSE,osErrorISR);
@@ -95,3 +134,16 @@ tchStatus tch_mtx_destroy(tch_mtx* mtx){
 		return (tchStatus)tch_port_enterSvFromUsr(SV_MTX_DESTROY,(uint32_t)mtx,0);
 	}
 }
+/*
+tchStatus tch_mtx_destroy(tch_mtx* mtx){
+	if(tch_port_isISR()){
+		tch_kernel_errorHandler(FALSE,osErrorISR);
+		return osErrorISR;
+	}else{
+		if(!(mtx->key > MTX_INIT_MARK)){
+			return osErrorResource;
+		}
+		mtx->key = 0;
+		return (tchStatus)tch_port_enterSvFromUsr(SV_MTX_DESTROY,(uint32_t)mtx,0);
+	}
+}*/

--- a/source/sys/tch_sys.c
+++ b/source/sys/tch_sys.c
@@ -59,6 +59,11 @@ void tch_kernelInit(void* arg){
 	if(!tch_sys_instance.tch_api.Device)
 		tch_kernel_errorHandler(FALSE,osErrorValue);
 
+//	int dval = 1;
+//	int tval = 5;
+
+//	int result = tch_port_exclusiveCompare(&dval,tval,10);
+
 
 	if(!tch_kernel_initPort()){
 		tch_kernel_errorHandler(FALSE,osErrorOS);
@@ -101,15 +106,16 @@ void tch_kernelInit(void* arg){
 
 
 void tch_kernelSvCall(uint32_t sv_id,uint32_t arg1, uint32_t arg2){
-	tch_exc_stack* sp = (tch_exc_stack*)tch_port_getThreadSP();
 	tch_thread_header* cth = NULL;
 	tch_thread_header* nth = NULL;
-
+	tch_exc_stack* sp = NULL;
 	switch(sv_id){
 	case SV_EXIT_FROM_SV:
+		sp = (tch_exc_stack*)tch_port_getThreadSP();
 		sp++;
 		tch_port_setThreadSP((uint32_t)sp);
-		sp->R0 = arg1;                ///< return kernel call result
+		__DMB();
+		__ISB();             ///< return kernel call result
 		tch_port_kernel_unlock();
 		return;
 	case SV_THREAD_START:             // thread pointer arg1
@@ -123,7 +129,7 @@ void tch_kernelSvCall(uint32_t sv_id,uint32_t arg1, uint32_t arg2){
 		return;
 	case SV_THREAD_RESUME:
 		nth = tch_schedResume((tch_thread_queue*)arg1,osOK);
-		nth->t_ctx->kRetv = osOK;
+		tch_kernelSetResult(nth,osOK);
 		return;
 	case SV_THREAD_RESUMEALL:
 		tch_schedResumeAll((tch_thread_queue*)arg1,osOK);
@@ -147,34 +153,36 @@ void tch_kernelSvCall(uint32_t sv_id,uint32_t arg1, uint32_t arg2){
 				                                             /// of single thread
 				                                             ///
 			}
-			sp->R0 = osOK;
+			tch_kernelSetResult(cth,osOK);
 			return;
 		}else{                                                 ///< otherwise, make thread block
 			tch_schedSuspend((tch_thread_queue*)&((tch_mtx*) arg1)->que,arg2);
 		}
 		return;
 	case SV_MTX_UNLOCK:
+		cth = (tch_thread_header*) tch_schedGetRunningThread();
 		if(((tch_mtx*) arg1)->key > MTX_INIT_MARK){
 			if(!--cth->t_lckCnt){
 				cth->t_prior = cth->t_svd_prior;
 			}
-			nth = tch_schedResume((tch_thread_queue*)&((tch_mtx*)arg1)->que,osOK);
+			if(!tch_listIsEmpty((tch_thread_queue*)&((tch_mtx*)arg1)->que))
+				nth = tch_schedResume((tch_thread_queue*)&((tch_mtx*)arg1)->que,osOK);
 			if(nth){
 				((tch_mtx*) arg1)->key |= (uint32_t)nth;
-				nth->t_ctx->kRetv = osOK;
+				nth->t_kRet = osOK;
 			}else{
 				((tch_mtx*) arg1)->key = MTX_INIT_MARK;
 			}
-			sp->R0 = osOK;
+			tch_kernelSetResult(cth,osOK);
 		}else{
-			sp->R0 = osErrorResource;    ///< this mutex is not initialized yet.
+			tch_kernelSetResult(cth,osErrorResource);    ///< this mutex is not initialized yet.
 		}
 		return;
 	case SV_MTX_DESTROY:
 		while(!tch_listIsEmpty(&((tch_mtx*)arg1)->que)){               ///< check waiting thread in mtx entry
 			nth = (tch_thread_header*) tch_listDequeue((tch_lnode_t*)&((tch_mtx*) arg1)->que);
 			nth = (tch_thread_header*) ((tch_lnode_t*) nth - 1);
-			nth->t_ctx->kRetv = osErrorResource;
+			nth->t_kRet = osErrorResource;
 			nth->t_waitQ = NULL;
 			tch_schedReady(nth);                    ///< if there is thread waiting,put it ready state
 		}
@@ -187,13 +195,12 @@ void tch_kernelSvCall(uint32_t sv_id,uint32_t arg1, uint32_t arg2){
 	case SV_SIG_MATCH:
 		cth = (tch_thread_header*) arg1;
 		nth = tch_schedResume((tch_thread_queue*)&cth->t_sig.sig_wq,osOK);
-		nth->t_ctx->kRetv = osOK;
 		return;
 	case SV_MEM_MALLOC:
-		sp->R0 = (uint32_t)Sys->tch_heap_handle->alloc(Sys->tch_heap_handle,arg1);
+		tch_kernelSetResult(tch_currentThread,(uint32_t)Sys->tch_heap_handle->alloc(Sys->tch_heap_handle,arg1));
 		return;
 	case SV_MEM_FREE:
-		sp->R0 = Sys->tch_heap_handle->free(Sys->tch_heap_handle,(void*)arg1);
+		tch_currentThread = Sys->tch_heap_handle->free(Sys->tch_heap_handle,(void*)arg1);
 		return;
 	case SV_ASYNC_START:
 		tch_listEnqueuePriority(&sysThread.asynTaskQ,(tch_lnode_t*)arg1,tch_async_comp);

--- a/source/usr/main.cpp
+++ b/source/usr/main.cpp
@@ -16,7 +16,6 @@
 #include "tch.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <string>
 
 
 typedef struct person{
@@ -32,6 +31,9 @@ typedef struct classroom {
 tch_thread_id childThread;
 static DECLARE_THREADROUTINE(childthread_routine);
 static DECLARE_THREADSTACK(childthr_stack,1 << 11);
+static void race(tch* api);
+
+volatile tch_mtx tmtx;
 
 static BOOL onBtnPressed(tch_gpio_handle* gpio,uint8_t pin);
 tch_gpio_handle* led  = NULL;
@@ -39,13 +41,16 @@ tch_gpio_handle* btn  = NULL;
 
 static DECL_ASYNC_TASK(async_job);
 tch_async_id async_id;
-
+uint8_t mcnt;
+static void dummyfunc(void* arg, uint32_t a);
+void (*dummyfn)(void* arg,uint32_t a);
 int main(void* arg) {
 
-
-	person* p = new person();
-	delete p;
+	dummyfn = dummyfunc;
+	tch_mtx* mmtx = &tmtx;
 	tch* api = (tch*) arg;
+
+	api->Mtx->create(mmtx);
 
 	tch_gpio_cfg iocfg;
 	tch_gpio_evCfg evcfg;
@@ -77,22 +82,59 @@ int main(void* arg) {
 	api->Thread->start(childThread);
 
 
-	float fVal = 0.f;
 	while(1){
-		fVal += 0.02f;
 		led->out(led,bSet);
 		api->Thread->sleep(100);
+		for(mcnt = 0;mcnt < 200;mcnt++){
+	//		race(api);
+			if(api->Mtx->lock(mmtx,osWaitForever) == osOK)
+				api->Mtx->unlock(mmtx);
+		}
 		led->out(led,bClear);
 		api->Thread->sleep(100);
-		btn->listen(btn,osWaitForever);
-		classroom* clp = new classroom();
+		for(mcnt = 0;mcnt < 200;mcnt++){
+			//race(api);
+			if(api->Mtx->lock(mmtx,osWaitForever) == osOK){
+				api->Thread->sleep(0);
+				api->Mtx->unlock(mmtx);
+			}
+		}
+		for(mcnt = 0;mcnt < 200;mcnt++){
+			if(api->Mtx->lock(mmtx,osWaitForever) == osOK){
+				api->Thread->sleep(0);
+				api->Mtx->unlock(mmtx);
+			}
+		}
 
+
+		btn->listen(btn,osWaitForever);
+		dummyfn(mmtx,osWaitForever);
+
+		for(mcnt = 0;mcnt < 200;mcnt++){
+			if(api->Mtx->lock(mmtx,osWaitForever) == osOK){
+				api->Thread->sleep(0);
+				api->Mtx->unlock(mmtx);
+			}
+		}
+		classroom* clp = new classroom();
 		classroom* acls = (classroom*)malloc(sizeof(classroom));
 		delete clp;
 		free(acls);
+/*             Mtx Race 부분이 이 위치에 있을 때 종종 Mtx Parameter가 전달이 안되는 경우가 ㅅ애긴다.
+ *
+ */
+
+	//	api->Thread->sleep(0);
 	}
 	return 0;
 }
+
+static void dummyfunc(void* arg, uint32_t a){
+	if(arg == 0){
+		a++;
+	}
+}
+
 
 uint32_t prscnt = 0;
 BOOL onBtnPressed(tch_gpio_handle* gpio,uint8_t pin){
@@ -100,6 +142,7 @@ BOOL onBtnPressed(tch_gpio_handle* gpio,uint8_t pin){
 	return TRUE;
 }
 
+uint8_t ccnt;
 DECLARE_THREADROUTINE(childthread_routine){
 	tch* api = (tch*) arg;
 	tch_gpio_cfg iocfg;
@@ -109,23 +152,43 @@ DECLARE_THREADROUTINE(childthread_routine){
 	iocfg.Speed = api->Device->gpio->Speed.Low;
 	tch_gpio_handle* bled = api->Device->gpio->allocIo(gpIo_5,7,&iocfg,osWaitForever,ActOnSleep);
 
-	async_id = api->Async->create(async_job,arg,api->Async->Prior.Normal);
-	tchStatus result = api->Async->blockedstart(async_id,osWaitForever);
+	tch_gpio_handle* btntoggle = api->Device->gpio->allocIo(gpIo_0,6,&iocfg,osWaitForever,ActOnSleep);
 
+	tch_mtx* mmtx = &tmtx;
+
+//	async_id = api->Async->create(async_job,arg,api->Async->Prior.Normal);
+//	tchStatus result = api->Async->blockedstart(async_id,osWaitForever);
 	while(1){
 		bled->out(bled,bSet);
 		api->Thread->sleep(20);
+		for(ccnt = 0;ccnt < 200;ccnt++){
+			btntoggle->out(btntoggle,bSet);
+			if(api->Mtx->lock(mmtx,osWaitForever) == osOK){
+				btntoggle->out(btntoggle,bClear);
+				api->Mtx->unlock(mmtx);
+			}
+		}
 		bled->out(bled,bClear);
 		api->Thread->sleep(20);
+		for(ccnt = 0;ccnt < 200;ccnt++){
+			btntoggle->out(btntoggle,bSet);
+			if(api->Mtx->lock(mmtx,osWaitForever) == osOK)
+				btntoggle->out(btntoggle,bClear);
+				api->Mtx->unlock(mmtx);
+		}
 	}
 	return 0;
 }
 
+void race(tch* api){
+	if(api->Mtx->lock(&tmtx,osWaitForever) != osOK)
+		return;
+//	api->Thread->sleep(0);
+	api->Mtx->unlock(&tmtx);
+}
+
 
 static DECL_ASYNC_TASK(async_job){
-	person* p = new person();
-	p->age = 25;
-	p->sex = 1;
 	((tch*)arg)->Async->notify(id,osOK);
 	return TRUE;
 }

--- a/tchConfig.mk
+++ b/tchConfig.mk
@@ -22,7 +22,7 @@ endif
 
 # FPU Option   HARD | SOFT | NO
 ifeq ($(FPU),)
-	FPU = HARD
+	FPU = SOFT
 endif
 
 # Hardware Vendor Option


### PR DESCRIPTION
   originally, system call result is passed to thread using part of
   saved context of the thread, but it made error if function is called
   just after blocking system call by modifying register.
   this patch also includes fix for thread control block structure, which is reated to return result of system blocking call
   to thread
