### PR TITLE
1. alignment is mandated by hardware sometime

### DIFF
--- a/include/kernel/mm/tch_mm.h
+++ b/include/kernel/mm/tch_mm.h
@@ -145,6 +145,7 @@
 								PERM_OTHER_WR |\
 								PERM_OTHER_XC)
 
+
 #define PERM_MSK				(PERM_KERNEL_ALL | PERM_OWNER_ALL | PERM_OTHER_ALL)
 
 #define perm_is_only_priv(flags)		(!(flags & (PERM_OWNER_ALL || PERM_OTHER_ALL)))

--- a/source/kernel/tch_lwtask.c
+++ b/source/kernel/tch_lwtask.c
@@ -22,7 +22,7 @@ struct lw_task {
 	tch_mtxId			lock;
 	tch_condvId			condv;
 	cdsl_dlistNode_t	tsk_qn;
-}__attribute__((packed));
+};
 
 static DECLARE_COMPARE_FN(lwtask_priority_rule);
 


### PR DESCRIPTION
  -> arm exclusive ldr / str family has access alignment restriction
  -> so any dynamic allocation is performed with unaligned struct can affect other object's alignment
   decision candidate 1. reflect interface of dynamic allocation so user can choose alignment option
   decision candidate 2. all dynamically allocated object is padded to meet marginal alignment requirement of hardware