### PR TITLE
implementing unit testing & fix kernel bugs.

### DIFF
--- a/include/kernel/tch_ktypes.h
+++ b/include/kernel/tch_ktypes.h
@@ -139,57 +139,6 @@ struct tch_thread_kheader_s {
 
 #define SV_EXIT_FROM_SV                  ((uint32_t) 0x00)
 
-#define SV_EV_INIT						 ((uint32_t) 0x15)
-#define SV_EV_UPDATE                     ((uint32_t) 0x16)              ///< Supervisor call id for setting / clearing event flag
-#define SV_EV_WAIT                       ((uint32_t) 0x17)              ///< Supervisor call id for blocking to wait event
-#define SV_EV_DEINIT                     ((uint32_t) 0x18)              ///< Supervisor call id for destroying event node
-
-#define SV_THREAD_CREATE				 ((uint32_t) 0x1A)				///< Supervisor call id for creating thread
-#define SV_THREAD_START                  ((uint32_t) 0x20)              ///< Supervisor call id for starting thread
-#define SV_THREAD_TERMINATE              ((uint32_t) 0x21)              ///< Supervisor call id for terminate thread      /* Not Implemented here */
-#define SV_THREAD_YIELD                  ((uint32_t) 0x22)              ///< Supervisor call id for yeild cpu for specific  amount of time
-#define SV_THREAD_JOIN                   ((uint32_t) 0x23)              ///< Supervisor call id for wait another thread is terminated
-#define SV_THREAD_SUSPEND                ((uint32_t) 0x24)
-#define SV_THREAD_RESUME                 ((uint32_t) 0x25)
-#define SV_THREAD_RESUMEALL              ((uint32_t) 0x26)
-#define SV_THREAD_DESTROY                ((uint32_t) 0x27)
-#define SV_THREAD_SLEEP                  ((uint32_t) 0x28)               ///< Supervisor call id to put thread in low power stand-by mode
-
-#define SV_MTX_CREATE					 ((uint32_t) 0x40)
-#define SV_MTX_LOCK						 ((uint32_t) 0x29)
-#define SV_MTX_UNLOCK					 ((uint32_t) 0x2A)
-#define SV_MTX_DESTROY					 ((uint32_t) 0x2B)
-
-#define SV_CONDV_INIT					 ((uint32_t) 0x2C)
-#define SV_CONDV_WAIT					 ((uint32_t) 0x2D)
-#define SV_CONDV_WAKE					 ((uint32_t) 0x2E)
-#define SV_CONDV_DEINIT					 ((uint32_t) 0x2F)
-
-#define SV_MSGQ_INIT					 ((uint32_t) 0x30)
-#define SV_MSGQ_PUT                      ((uint32_t) 0x31)              ///< Supervisor call id to put msg to msgq
-#define SV_MSGQ_GET                      ((uint32_t) 0x32)              ///< Supervisor call id to get msg from msgq
-#define SV_MSGQ_DEINIT                   ((uint32_t) 0x33)              ///< Supervisro call id to destoy msgq
-
-#define SV_MEMP_ALLOC                    ((uint32_t) 0x34)               ///< Supervisor call id to allocate memory chunk form mem pool
-#define SV_MEMP_FREE                     ((uint32_t) 0x35)               ///< Supervisor call id to free memory chunk into mem pool
-
-#define SV_MAILQ_INIT					 ((uint32_t) 0x36)
-#define SV_MAILQ_ALLOC                   ((uint32_t) 0x37)               ///< Supervisor call id to allocate mail
-#define SV_MAILQ_FREE                    ((uint32_t) 0x38)               ///< Supervisor call id to free mail
-#define SV_MAILQ_DEINIT                  ((uint32_t) 0x39)               ///< Supervisor call id to destroy mailq
-
-#define SV_BAR_INIT 	                 ((uint32_t) 0x3A)               ///< Supervisor call id to post Async Kernel Task
-#define SV_BAR_DEINIT   	             ((uint32_t) 0x3B)               ///< Supervisor call id to notify completion of async kernel task
-
-#define SV_SHMEM_ALLOC				 	 ((uint32_t) 0x3C)
-#define SV_SHMEM_FREE				  	 ((uint32_t) 0x3D)
-#define SV_SHMEM_AVAILABLE			 	 ((uint32_t) 0x3E)
-
-#define SV_HAL_ENABLE_ISR                ((uint32_t) 0xFD)
-#define SV_HAL_DISABLE_ISR               ((uint32_t) 0xFC)
-
-
-
 
 #ifdef __cplusplus
 }

--- a/source/kernel/mm/nommu/tch_mm.c
+++ b/source/kernel/mm/nommu/tch_mm.c
@@ -97,6 +97,8 @@ BOOL tch_mmProcInit(tch_thread_kheader* thread,struct proc_header* proc_header){
 			return FALSE;
 		mmp->dynamic = parent_mm->dynamic;
 		cdsl_dlistInit(&mmp->kobj_list);
+		cdsl_dlistInit(&mmp->alc_list);
+		cdsl_dlistInit(&mmp->shm_list);
 	}
 
 	if(mmp->text_region && mmp->bss_region && mmp->data_region){

--- a/source/kernel/mm/tch_kmalloc.c
+++ b/source/kernel/mm/tch_kmalloc.c
@@ -76,6 +76,7 @@ void* kmalloc(size_t sz){
 	if(!chunk){
 		return NULL;
 	}
+	cdsl_dlistInit(&chunk->alc_ln);
 	cdsl_dlistPutHead((cdsl_dlistNode_t*) &current_mm->alc_list,&chunk->alc_ln);			// add alloc list
 	return (void*) ((size_t) chunk + sizeof(struct alloc_header));
 }

--- a/source/kernel/mm/tch_shm.c
+++ b/source/kernel/mm/tch_shm.c
@@ -78,6 +78,7 @@ DEFINE_SYSCALL_1(shmem_alloc,size_t,sz,void*){
 	}
 
 	chnk = wt_malloc(&shm_root,asz);
+	cdsl_dlistInit(&chnk->alc_ln);
 	cdsl_dlistPutHead(&current->kthread->mm.shm_list,&chnk->alc_ln);
 	return &chnk[1];
 }
@@ -98,9 +99,10 @@ DEFINE_SYSCALL_1(shmem_cleanup,tch_threadId,tid,tchStatus){
 	cdsl_dlistNode_t* shm_alc = &kth->mm.shm_list;
 	struct shmalloc_header* chnk = NULL;
 	while(!cdsl_dlistIsEmpty(shm_alc)){
-		 chnk = cdsl_dlistDequeue(shm_alc);
+		 chnk = (struct shmalloc_header*) cdsl_dlistDequeue(shm_alc);
 		 if(!chnk)
 			 return tchErrorHeapCorruption;
+		 chnk = container_of(chnk,struct shmalloc_header,alc_ln);
 		 if(wt_free(&shm_root,chnk) == WT_ERROR)
 			 return tchErrorHeapCorruption;
 	}

--- a/source/kernel/tch_fs.c
+++ b/source/kernel/tch_fs.c
@@ -12,9 +12,12 @@
  */
 
 
-
-
 #include "kernel/tch_kernel.h"
 #include "kernel/tch_fs.h"
+
+// mount file system
+// open directory
+// release directory
+//
 
 

--- a/source/kernel/tch_lock.c
+++ b/source/kernel/tch_lock.c
@@ -222,8 +222,10 @@ static tchStatus mutex_deinit(tch_mtxCb* mcb){
 	if(!MTX_ISVALID(mcb))
 		return tchErrorParameter;
 	MTX_INVALIDATE(mcb);
-	tch_threadSetPriority(current,mcb->svdPrior);
-	mcb->svdPrior = Idle;
+	if(!(--current->kthread->lckCnt)){
+		tch_threadSetPriority(mcb->own,mcb->svdPrior);
+		mcb->svdPrior = Idle;
+	}
 	tch_schedWake(&mcb->que,SCHED_THREAD_ALL,tchErrorResource,FALSE);
 	tch_unregisterKobject(&mcb->__obj);
 	return tchOK;

--- a/source/kernel/tch_mpool.c
+++ b/source/kernel/tch_mpool.c
@@ -70,7 +70,7 @@ tch_mpoolId tch_mpoolCreate(size_t sz,uint32_t plen){
 		blk = (uint8_t*) next;
 	}
 
-	*((void**) blk) = 0;
+	*((void**) blk) = 0;				// null indicate end of mem pool
 	tch_mpoolValidate(mpcb);
 	return (tch_mpoolId) mpcb;
 }

--- a/source/test/sys/monitor_test.c
+++ b/source/test/sys/monitor_test.c
@@ -58,16 +58,12 @@ tchStatus monitor_performTest(tch* api){
 	uint8_t* prod2stk = NULL;
 
 
-	tch_assert(api,cons1stk && cons2stk && prod1stk && prod2stk,tchErrorOS);
-
 	tch_threadCfg thcfg;
 	api->Thread->initCfg(&thcfg,consumerRoutine,Normal,512,0,"consumer1");
 	consumer1Thread = api->Thread->create(&thcfg,api);
 
 	api->Thread->initCfg(&thcfg,consumerRoutine,Normal,512,0,"consumer2");
 	consumer2Thread = api->Thread->create(&thcfg,api);
-
-
 
 
 	api->Thread->initCfg(&thcfg,producerRoutine,Normal,512,0,"producer1");

--- a/source/test/sys/thread_test.c
+++ b/source/test/sys/thread_test.c
@@ -22,10 +22,30 @@ tchStatus thread_performTest(tch* ctx){
 
 	kmstat(&init_mstat);
 
+	/**
+	 *  Memory Leakage Test
+	 *  create & destroy root thread
+	 */
+
 	while(cnt--){
 		threadStarted = FALSE;
 		ctx->Thread->initCfg(&tcfg,run,Normal,0,0,"test_run");
 		child = (tch_threadId) tch_threadCreateThread(&tcfg,bar,TRUE,TRUE,NULL);
+		ctx->Thread->start(child);
+		ctx->Barrier->wait(bar,tchWaitForever);
+		ctx->Thread->join(child,tchWaitForever);
+	}
+	kmstat(&fin_mstat);
+	if(fin_mstat.used != init_mstat.used)
+		return tchErrorOS;
+
+
+	kmstat(&init_mstat);
+
+	while(cnt--){
+		threadStarted = FALSE;
+		ctx->Thread->initCfg(&tcfg,run,Normal,0,0,"test_run");
+		child = (tch_threadId) tch_threadCreateThread(&tcfg,bar,FALSE,TRUE,NULL);
 		ctx->Thread->start(child);
 		ctx->Barrier->wait(bar,tchWaitForever);
 		ctx->Thread->join(child,tchWaitForever);

--- a/source/usr/app/test/app.c
+++ b/source/usr/app/test/app.c
@@ -7,9 +7,17 @@
 
 #include "tch.h"
 #include "thread_test.h"
+#include "mailq_test.h"
 
 int main(const tch* ctx){
-	thread_performTest(ctx);
+
+	thread_performTest((tch*) ctx);
+	mailq_performTest((tch*) ctx);
+
+	monitor_performTest((tch*) ctx);
+	semaphore_performTest((tch*) ctx);
+
+
 	while(TRUE){
 		ctx->Thread->sleep(1);
 	}


### PR DESCRIPTION
1. per-thread alloc list has been overwritten. it caused object allocated by parent thread is freed by
   child thread  @ tch_mm.c
2. mutex priority escallation is handled wrong way.
   in mutex destructor, kernel tries to restore original thread's priority which actually has already been restored in
   mutex unlocking.
3. allocated chunk's alloc header not initialized properly